### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/examples/main.toit
+++ b/examples/main.toit
@@ -19,12 +19,12 @@ main:
   dummy.set 1
 
   bus := spi.Bus
-    --mosi=gpio.Pin 13
-    --miso=gpio.Pin 12
-    --clock=gpio.Pin 14
+    --mosi=13
+    --miso=12
+    --clock=14
 
   device := bus.device
-    --cs=gpio.Pin 27
+    --cs=27
     --frequency=max31865.MAX-BUS-SPEED / 8  // Conservative bus speed choice.
     --mode=1
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name: max31865
 description: Driver for MAX31865 RTD-to-Digital Converter.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196
 dependencies:
   resistance_to_temperature:
     url: github.com/toitware/toit-resistance-to-temperature

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name: max31865
 description: Driver for MAX31865 RTD-to-Digital Converter.
 environment:
-  sdk: ^2.0.0-alpha.180
+  sdk: ^2.0.0-alpha.194.1
 dependencies:
   resistance_to_temperature:
     url: github.com/toitware/toit-resistance-to-temperature

--- a/src/provider.toit
+++ b/src/provider.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import spi
 import sensors.providers
 
@@ -13,10 +12,6 @@ MAJOR ::= 1
 MINOR ::= 0
 
 class Sensor_ implements providers.TemperatureSensor-v1:
-  clock_/gpio.Pin? := null
-  miso_/gpio.Pin? := null
-  mosi_/gpio.Pin? := null
-  cs_/gpio.Pin? := null
   spi_/spi.Bus? := null
   device_/spi.Device? := null
   sensor_/max31865.Driver? := null
@@ -24,12 +19,8 @@ class Sensor_ implements providers.TemperatureSensor-v1:
   constructor --clock/int --miso/int --mosi/int --cs/int?:
     is-exception := true
     try:
-      clock_ = gpio.Pin clock
-      miso_ = gpio.Pin miso
-      mosi_ = gpio.Pin mosi
-      cs_ = cs ? gpio.Pin cs : null
-      spi_ = spi.Bus --clock=clock_ --miso=miso_ --mosi=mosi_
-      device_ = spi_.device --cs=cs_ --frequency=max31865.MAX-BUS-SPEED
+      spi_ = spi.Bus --clock=clock --miso=miso --mosi=mosi
+      device_ = spi_.device --cs=cs --frequency=max31865.MAX-BUS-SPEED
       sensor_ = max31865.Driver device_
       is-exception = false
     finally:
@@ -47,18 +38,6 @@ class Sensor_ implements providers.TemperatureSensor-v1:
     if spi_:
       spi_.close
       spi_ = null
-    if cs_:
-      cs_.close
-      cs_ = null
-    if mosi_:
-      mosi_.close
-      mosi_ = null
-    if miso_:
-      miso_.close
-      miso_ = null
-    if clock_:
-      clock_.close
-      clock_ = null
 /**
 Installs the MAX31865 sensor.
 */


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.